### PR TITLE
Static math rendering via texmath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,7 @@ result
 result-*
 
 # direnv
-.direnv.do-results.json
+.direnv
+
+# do-skill workflow artifact
+.do-results.json

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ result
 result-*
 
 # direnv
-.direnv
+.direnv.do-results.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Revision history for heist-extra
 
-## 0.5.0.0 (2025-12-18)
+## 0.5.0.0 (unreleased)
 
 - Add syntax highlighting for code blocks using skylighting (#10)
 - Remove prism.js `language-*` class hack (no longer needed with static highlighting)
+- Add static math rendering for `$...$` and `$$...$$` via `texmath` (LaTeX → MathML at build time)
 
 ## 0.4.0.0 (2025-08-19)
 

--- a/heist-extra.cabal
+++ b/heist-extra.cabal
@@ -83,6 +83,8 @@ common shared
     , skylighting-core
     , skylighting-format-blaze-html
     , text
+    , texmath
+    , xml
     , xmlhtml
 
   hs-source-dirs:     src
@@ -100,5 +102,6 @@ library
     Heist.Extra.Splices.Pandoc.Render
     Heist.Extra.Splices.Pandoc.Skylighting
     Heist.Extra.Splices.Pandoc.TaskList
+    Heist.Extra.Splices.Pandoc.Texmath
     Heist.Extra.Splices.Tree
     Heist.Extra.TemplateState

--- a/src/Heist/Extra/Splices/Pandoc/Ctx.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Ctx.hs
@@ -34,6 +34,8 @@ data RenderCtx = RenderCtx
   , inlineSplice :: B.Inline -> Maybe (HI.Splice Identity)
   , enableSyntaxHighlighting :: Bool
   -- ^ Enable syntax highlighting for code blocks using skylighting
+  , enableStaticMath :: Bool
+  -- ^ Enable static (build-time) math rendering to MathML via texmath
   }
 
 mkRenderCtx ::
@@ -46,8 +48,10 @@ mkRenderCtx ::
   (RenderCtx -> B.Inline -> Maybe (HI.Splice Identity)) ->
   -- | Enable syntax highlighting for code blocks
   Bool ->
+  -- | Enable static math rendering to MathML
+  Bool ->
   H.HeistT Identity m RenderCtx
-mkRenderCtx classMap bS iS enableHighlighting = do
+mkRenderCtx classMap bS iS enableHighlighting enableStatic = do
   node <- H.getParamNode
   let ctx =
         RenderCtx
@@ -58,11 +62,12 @@ mkRenderCtx classMap bS iS enableHighlighting = do
           (bS ctx)
           (iS ctx)
           enableHighlighting
+          enableStatic
    in pure ctx
 
 emptyRenderCtx :: RenderCtx
 emptyRenderCtx =
-  RenderCtx Nothing (const B.nullAttr) (const B.nullAttr) mempty (const Nothing) (const Nothing) False
+  RenderCtx Nothing (const B.nullAttr) (const B.nullAttr) mempty (const Nothing) (const Nothing) False False
 
 -- | Strip any custom splicing out of the given render context
 ctxSansCustomSplicing :: RenderCtx -> RenderCtx

--- a/src/Heist/Extra/Splices/Pandoc/Ctx.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Ctx.hs
@@ -2,6 +2,10 @@
 
 module Heist.Extra.Splices.Pandoc.Ctx (
   RenderCtx (..),
+  RenderFeatures (..),
+  CodeBackend (..),
+  MathBackend (..),
+  defaultFeatures,
   mkRenderCtx,
   emptyRenderCtx,
   rewriteClass,
@@ -16,6 +20,36 @@ import Heist.Extra.Splices.Pandoc.Attr (concatAttr)
 import Heist.Interpreted qualified as HI
 import Text.Pandoc.Builder qualified as B
 import Text.XmlHtml qualified as X
+
+-- | Backend for syntax-highlighting fenced code blocks.
+data CodeBackend
+  = -- | Emit code blocks unhighlighted; consumer wires client-side JS if desired.
+    NoHighlighting
+  | -- | Tokenize at build time via @skylighting@.
+    Skylighting
+  deriving stock (Eq, Show)
+
+-- | Backend for rendering `$...$` / `$$...$$` math.
+data MathBackend
+  = -- | Emit raw delimiters for client-side JS (KaTeX, MathJax) to pick up.
+    NoStaticMath
+  | -- | Convert to MathML at build time via @texmath@.
+    StaticMathML
+  deriving stock (Eq, Show)
+
+{- | Which rendering features are active. Selecting a non-trivial backend
+per axis is independently extensible — adding a third math backend does
+not touch call sites for the code backend, and vice versa.
+-}
+data RenderFeatures = RenderFeatures
+  { codeHighlighting :: CodeBackend
+  , mathRendering :: MathBackend
+  }
+  deriving stock (Eq, Show)
+
+-- | Everything off — the historical default before either feature existed.
+defaultFeatures :: RenderFeatures
+defaultFeatures = RenderFeatures NoHighlighting NoStaticMath
 
 {- | The configuration context under which we must render a `Pandoc` document
  using the given Heist template.
@@ -32,10 +66,7 @@ data RenderCtx = RenderCtx
   , -- Custom render functions for AST nodes.
     blockSplice :: B.Block -> Maybe (HI.Splice Identity)
   , inlineSplice :: B.Inline -> Maybe (HI.Splice Identity)
-  , enableSyntaxHighlighting :: Bool
-  -- ^ Enable syntax highlighting for code blocks using skylighting
-  , enableStaticMath :: Bool
-  -- ^ Enable static (build-time) math rendering to MathML via texmath
+  , renderFeatures :: RenderFeatures
   }
 
 mkRenderCtx ::
@@ -46,12 +77,10 @@ mkRenderCtx ::
   (RenderCtx -> B.Block -> Maybe (HI.Splice Identity)) ->
   -- | Custom handling of AST inline nodes
   (RenderCtx -> B.Inline -> Maybe (HI.Splice Identity)) ->
-  -- | Enable syntax highlighting for code blocks
-  Bool ->
-  -- | Enable static math rendering to MathML
-  Bool ->
+  -- | Rendering feature selection (code highlighting, static math, …).
+  RenderFeatures ->
   H.HeistT Identity m RenderCtx
-mkRenderCtx classMap bS iS enableHighlighting enableStatic = do
+mkRenderCtx classMap bS iS features = do
   node <- H.getParamNode
   let ctx =
         RenderCtx
@@ -61,13 +90,12 @@ mkRenderCtx classMap bS iS enableHighlighting enableStatic = do
           classMap
           (bS ctx)
           (iS ctx)
-          enableHighlighting
-          enableStatic
+          features
    in pure ctx
 
 emptyRenderCtx :: RenderCtx
 emptyRenderCtx =
-  RenderCtx Nothing (const B.nullAttr) (const B.nullAttr) mempty (const Nothing) (const Nothing) False False
+  RenderCtx Nothing (const B.nullAttr) (const B.nullAttr) mempty (const Nothing) (const Nothing) defaultFeatures
 
 -- | Strip any custom splicing out of the given render context
 ctxSansCustomSplicing :: RenderCtx -> RenderCtx

--- a/src/Heist/Extra/Splices/Pandoc/Render.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Render.hs
@@ -15,7 +15,10 @@ import Heist qualified as H
 import Heist.Extra (runCustomNode)
 import Heist.Extra.Splices.Pandoc.Attr (concatAttr, rpAttr)
 import Heist.Extra.Splices.Pandoc.Ctx (
+  CodeBackend (..),
+  MathBackend (..),
   RenderCtx (..),
+  RenderFeatures (..),
   rewriteClass,
  )
 import Heist.Extra.Splices.Pandoc.Skylighting (highlightCode)
@@ -55,12 +58,11 @@ rpBlock' ctx@RenderCtx {..} b = case b of
       foldMapM (rpInline ctx) (convertRawInline [] is) >> pure [X.TextNode "\n"]
   B.CodeBlock (id', classes, attrs) s -> do
     let lang = listToMaybe classes
-        codeNodes =
-          if enableSyntaxHighlighting
-            then case highlightCode lang s of
-              Left err -> [X.Element "span" [("class", "error")] [X.TextNode err], X.TextNode s]
-              Right nodes -> nodes
-            else one $ X.TextNode s
+        codeNodes = case codeHighlighting renderFeatures of
+          Skylighting -> case highlightCode lang s of
+            Left err -> [X.Element "span" [("class", "error")] [X.TextNode err], X.TextNode s]
+            Right nodes -> nodes
+          NoHighlighting -> one $ X.TextNode s
     pure $
       one . X.Element "div" (rpAttr $ bAttr b) $
         one . X.Element "pre" mempty $
@@ -200,24 +202,13 @@ rpInline' ctx@RenderCtx {..} i = case i of
             one . X.TextNode $
               s
   B.Math mathType s ->
-    if enableStaticMath
-      then case renderMath mathType s of
+    pure $ case mathRendering renderFeatures of
+      StaticMathML -> case renderMath mathType s of
+        Right nodes -> nodes
         Left err ->
-          pure $
-            one . X.Element "span" [("class", "math error")] $
-              [X.TextNode err, X.TextNode ": ", X.TextNode s]
-        Right nodes -> pure nodes
-      else case mathType of
-        B.InlineMath ->
-          pure $
-            one . X.Element "span" [("class", "math inline")] $
-              one . X.TextNode $
-                "\\(" <> s <> "\\)"
-        B.DisplayMath ->
-          pure $
-            one . X.Element "span" [("class", "math display")] $
-              one . X.TextNode $
-                "$$" <> s <> "$$"
+          one . X.Element "span" [("class", "math error")] $
+            [X.TextNode err, X.TextNode ": ", X.TextNode s]
+      NoStaticMath -> renderMathPassthrough mathType s
   B.Link attr is (url, tit) -> do
     let attrs =
           catMaybes [Just ("href", url), guard (not $ T.null tit) >> pure ("title", tit)]
@@ -310,6 +301,15 @@ rawNode wrapperTag s =
   one . X.Element wrapperTag (one ("xmlhtmlRaw", "")) $
     one . X.TextNode $
       s
+
+-- | Emit raw LaTeX wrapped in a span for client-side rendering (KaTeX/MathJax).
+renderMathPassthrough :: B.MathType -> Text -> [X.Node]
+renderMathPassthrough mathType s =
+  one . X.Element "span" [("class", klass)] . one . X.TextNode $ wrapped
+  where
+    (klass, wrapped) = case mathType of
+      B.InlineMath -> ("math inline", "\\(" <> s <> "\\)")
+      B.DisplayMath -> ("math display", "$$" <> s <> "$$")
 
 -- | Convert Pandoc AST inlines to raw text.
 plainify :: [B.Inline] -> Text

--- a/src/Heist/Extra/Splices/Pandoc/Render.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Render.hs
@@ -20,6 +20,7 @@ import Heist.Extra.Splices.Pandoc.Ctx (
  )
 import Heist.Extra.Splices.Pandoc.Skylighting (highlightCode)
 import Heist.Extra.Splices.Pandoc.TaskList qualified as TaskList
+import Heist.Extra.Splices.Pandoc.Texmath (renderMath)
 import Heist.Interpreted qualified as HI
 import Text.Pandoc.Builder qualified as B
 import Text.Pandoc.Definition (Pandoc (..))
@@ -199,17 +200,24 @@ rpInline' ctx@RenderCtx {..} i = case i of
             one . X.TextNode $
               s
   B.Math mathType s ->
-    case mathType of
-      B.InlineMath ->
-        pure $
-          one . X.Element "span" [("class", "math inline")] $
-            one . X.TextNode $
-              "\\(" <> s <> "\\)"
-      B.DisplayMath ->
-        pure $
-          one . X.Element "span" [("class", "math display")] $
-            one . X.TextNode $
-              "$$" <> s <> "$$"
+    if enableStaticMath
+      then case renderMath mathType s of
+        Left err ->
+          pure $
+            one . X.Element "span" [("class", "math error")] $
+              [X.TextNode err, X.TextNode ": ", X.TextNode s]
+        Right nodes -> pure nodes
+      else case mathType of
+        B.InlineMath ->
+          pure $
+            one . X.Element "span" [("class", "math inline")] $
+              one . X.TextNode $
+                "\\(" <> s <> "\\)"
+        B.DisplayMath ->
+          pure $
+            one . X.Element "span" [("class", "math display")] $
+              one . X.TextNode $
+                "$$" <> s <> "$$"
   B.Link attr is (url, tit) -> do
     let attrs =
           catMaybes [Just ("href", url), guard (not $ T.null tit) >> pure ("title", tit)]

--- a/src/Heist/Extra/Splices/Pandoc/Texmath.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Texmath.hs
@@ -44,4 +44,7 @@ fromContent :: XL.Content -> [X.Node]
 fromContent = \case
   XL.Elem e -> [fromElement e]
   XL.Text cd -> [X.TextNode (toText $ XL.cdData cd)]
-  XL.CRef _ -> []
+  -- texmath's MathML writer emits Unicode directly, so this branch is
+  -- unreachable in practice. Preserve the entity literally rather than
+  -- silently dropping it, so any future regression is visible.
+  XL.CRef ref -> [X.TextNode $ "&" <> toText ref <> ";"]

--- a/src/Heist/Extra/Splices/Pandoc/Texmath.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Texmath.hs
@@ -1,50 +1,21 @@
-{- | Static math rendering using texmath.
-
-This module converts LaTeX math expressions to MathML at build time,
-producing XmlHtml nodes that browsers render natively without JavaScript.
--}
+-- | Static math rendering via @texmath@ (LaTeX → MathML at build time).
 module Heist.Extra.Splices.Pandoc.Texmath (
   renderMath,
 ) where
 
+import Data.Text.Encoding qualified as TE
 import Text.Pandoc.Builder qualified as B
 import Text.TeXMath (DisplayType (..), readTeX, writeMathML)
-import Text.XML.Light qualified as XL
+import Text.XML.Light.Output (showElement)
 import Text.XmlHtml qualified as X
 
-{- | Render math using texmath.
- Returns MathML nodes for the given LaTeX source. Returns Left with
- error message if the LaTeX fails to parse.
--}
-renderMath ::
-  B.MathType ->
-  -- | LaTeX math source
-  Text ->
-  Either Text [X.Node]
-renderMath mathType src =
-  case readTeX src of
-    Left err -> Left err
-    Right exps -> Right [fromElement $ writeMathML (displayType mathType) exps]
+renderMath :: B.MathType -> Text -> Either Text [X.Node]
+renderMath mathType src = do
+  exps <- readTeX src
+  let mathml = toText . showElement $ writeMathML (displayType mathType) exps
+  first toText . fmap X.docContent $
+    X.parseXML "<texmath>" (TE.encodeUtf8 mathml)
   where
     displayType = \case
       B.InlineMath -> DisplayInline
       B.DisplayMath -> DisplayBlock
-
-fromElement :: XL.Element -> X.Node
-fromElement (XL.Element name attrs content _) =
-  X.Element
-    (toText $ XL.qName name)
-    (map fromAttr attrs)
-    (concatMap fromContent content)
-
-fromAttr :: XL.Attr -> (Text, Text)
-fromAttr (XL.Attr k v) = (toText $ XL.qName k, toText v)
-
-fromContent :: XL.Content -> [X.Node]
-fromContent = \case
-  XL.Elem e -> [fromElement e]
-  XL.Text cd -> [X.TextNode (toText $ XL.cdData cd)]
-  -- texmath's MathML writer emits Unicode directly, so this branch is
-  -- unreachable in practice. Preserve the entity literally rather than
-  -- silently dropping it, so any future regression is visible.
-  XL.CRef ref -> [X.TextNode $ "&" <> toText ref <> ";"]

--- a/src/Heist/Extra/Splices/Pandoc/Texmath.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Texmath.hs
@@ -1,0 +1,47 @@
+{- | Static math rendering using texmath.
+
+This module converts LaTeX math expressions to MathML at build time,
+producing XmlHtml nodes that browsers render natively without JavaScript.
+-}
+module Heist.Extra.Splices.Pandoc.Texmath (
+  renderMath,
+) where
+
+import Text.Pandoc.Builder qualified as B
+import Text.TeXMath (DisplayType (..), readTeX, writeMathML)
+import Text.XML.Light qualified as XL
+import Text.XmlHtml qualified as X
+
+{- | Render math using texmath.
+ Returns MathML nodes for the given LaTeX source. Returns Left with
+ error message if the LaTeX fails to parse.
+-}
+renderMath ::
+  B.MathType ->
+  -- | LaTeX math source
+  Text ->
+  Either Text [X.Node]
+renderMath mathType src =
+  case readTeX src of
+    Left err -> Left err
+    Right exps -> Right [fromElement $ writeMathML (displayType mathType) exps]
+  where
+    displayType = \case
+      B.InlineMath -> DisplayInline
+      B.DisplayMath -> DisplayBlock
+
+fromElement :: XL.Element -> X.Node
+fromElement (XL.Element name attrs content _) =
+  X.Element
+    (toText $ XL.qName name)
+    (map fromAttr attrs)
+    (concatMap fromContent content)
+
+fromAttr :: XL.Attr -> (Text, Text)
+fromAttr (XL.Attr k v) = (toText $ XL.qName k, toText v)
+
+fromContent :: XL.Content -> [X.Node]
+fromContent = \case
+  XL.Elem e -> [fromElement e]
+  XL.Text cd -> [X.TextNode (toText $ XL.cdData cd)]
+  XL.CRef _ -> []


### PR DESCRIPTION
**LaTeX math now renders to MathML at build time**, so documents with `$...$` / `$$...$$` no longer need a KaTeX or MathJax JS bundle to become readable. Mirrors the skylighting approach from #10: `texmath` tokenizes and emits the tree at build time; the browser renders the resulting `<math>` element natively.

Along the way the per-feature `Bool` scheme in `RenderCtx` was replaced with a single `RenderFeatures` record carrying sum-typed backends (`CodeBackend = NoHighlighting | Skylighting`, `MathBackend = NoStaticMath | StaticMathML`). *A post-implement `/hickey` + `/lowy` pass flagged that bolting another trailing `Bool` onto `mkRenderCtx` for every new feature would scale linearly with features and break call sites each time.* Named record + sum-typed axes make adding a third backend (Typst, server-side KaTeX, whatever) zero-cost at the call site.

> **Breaking change for consumers (Emanote):** `enableSyntaxHighlighting :: Bool` is gone. Callers pass a `RenderFeatures { codeHighlighting = Skylighting | NoHighlighting, mathRendering = StaticMathML | NoStaticMath }` to `mkRenderCtx`. The mapping from the old `Bool` is trivial (`True → Skylighting`, `False → NoHighlighting`).

The actual XML↔XmlHtml conversion went through a `/simplify` pass too — the first cut hand-rolled a recursive `Text.XML.Light.Element → XmlHtml.Node` walker, which turned out to be unnecessary once you notice `xmlhtml`'s `parseXML` will happily re-parse the serialized MathML. Dropped ~20 lines and the CRef-handling branch.

Not listed as a dependency bump because `0.5.0.0` is still unreleased — the changelog folds this into the existing unreleased entry.