### PR TITLE
RenderCtx.idPrefix: namespace footnote ids across nested renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,16 @@
 # Revision history for heist-extra
 
-## 0.5.1.0 (unreleased)
-
-- `RenderCtx` gains an `idPrefix` field (default `""`) and a new
-  `footnote:id` splice is exposed. The splice emits
-  `idPrefix <> show idx` and is intended for the `id="…"` attributes
-  on footnote refs and list items. Unprefixed rendering is unchanged;
-  callers only need to act when they render multiple documents into a
-  single page (e.g. note embedding) and want to namespace footnote IDs.
-
 ## 0.5.0.0 (unreleased)
 
 - Add syntax highlighting for code blocks using skylighting (#10)
 - Remove prism.js `language-*` class hack (no longer needed with static highlighting)
 - Add static math rendering for `$...$` and `$$...$$` via `texmath` (LaTeX → MathML at build time)
+- `RenderCtx` gains an `idPrefix` field (default `""`) and a new
+  `footnote:id` splice is exposed (#12). The splice emits
+  `idPrefix <> show idx` and is intended for the `id="…"` attributes
+  on footnote refs and list items. Unprefixed rendering is unchanged;
+  callers only need to act when they render multiple documents into a
+  single page (e.g. note embedding) and want to namespace footnote IDs.
 
 ## 0.4.0.0 (2025-08-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   on footnote refs and list items. Unprefixed rendering is unchanged;
   callers only need to act when they render multiple documents into a
   single page (e.g. note embedding) and want to namespace footnote IDs.
+- Re-export `renderPandocWith` so consumers can render a `Pandoc` doc
+  without emitting a trailing footnote list — required whenever a
+  custom block/inline splice nests another `pandocSplice` call, since
+  the outer one already gathers every `B.Note` in the AST and would
+  otherwise produce a duplicate footnote listing.
 
 ## 0.4.0.0 (2025-08-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@
   on footnote refs and list items. Unprefixed rendering is unchanged;
   callers only need to act when they render multiple documents into a
   single page (e.g. note embedding) and want to namespace footnote IDs.
-- Re-export `renderPandocWith` so consumers can render a `Pandoc` doc
-  without emitting a trailing footnote list — required whenever a
-  custom block/inline splice nests another `pandocSplice` call, since
-  the outer one already gathers every `B.Note` in the AST and would
-  otherwise produce a duplicate footnote listing.
+- Add `pandocSpliceWithoutFootnoteList`: renders a `Pandoc` doc,
+  wires footnote refs, but does not emit the trailing `<ol>` of
+  footnote definitions. Intended for custom block renderers (e.g.
+  callout bodies) that are themselves invoked inside an outer
+  `pandocSplice` — the outer already emits the document-level list
+  via `gatherFootnotes`, so the nested render must not emit a second
+  copy.
+- Re-export `renderPandocWith` for callers that want to take over
+  footnote handling entirely.
 
 ## 0.4.0.0 (2025-08-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Revision history for heist-extra
 
+## 0.5.1.0 (unreleased)
+
+- `RenderCtx` gains an `idPrefix` field (default `""`) and a new
+  `footnote:id` splice is exposed. The splice emits
+  `idPrefix <> show idx` and is intended for the `id="…"` attributes
+  on footnote refs and list items. Unprefixed rendering is unchanged;
+  callers only need to act when they render multiple documents into a
+  single page (e.g. note embedding) and want to namespace footnote IDs.
+
 ## 0.5.0.0 (unreleased)
 
 - Add syntax highlighting for code blocks using skylighting (#10)

--- a/heist-extra.cabal
+++ b/heist-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               heist-extra
-version:            0.5.1.0
+version:            0.5.0.0
 license:            MIT
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/heist-extra.cabal
+++ b/heist-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               heist-extra
-version:            0.5.0.0
+version:            0.5.1.0
 license:            MIT
 copyright:          2022 Sridhar Ratnakumar
 maintainer:         srid@srid.ca

--- a/src/Heist/Extra/Splices/Pandoc.hs
+++ b/src/Heist/Extra/Splices/Pandoc.hs
@@ -1,11 +1,11 @@
 module Heist.Extra.Splices.Pandoc (
   RenderCtx (..),
   pandocSplice,
-  -- | Render a `Pandoc` doc /without/ emitting a trailing footnote
-  -- list. Intended for callers nested inside a `pandocSplice` — the
-  -- outer call already gathered every `B.Note` in the AST (including
-  -- inside this callee's input) and will render the document-level
-  -- footnote list, so the inner render must not emit its own copy.
+  pandocSpliceWithoutFootnoteList,
+
+  -- | Render a `Pandoc` doc with no splice wiring beyond what the given
+  -- context already holds. Exposed for callers that take over footnote
+  -- handling themselves.
   renderPandocWith,
   -- | To delegate rendering of blocks and inlines from a custom splice.
   rpBlock,
@@ -29,20 +29,38 @@ import Heist.Extra.Splices.Pandoc.Render (
 import Heist.Interpreted qualified as HI
 import Text.Pandoc.Definition (Pandoc (..))
 
--- | A splice to render a Pandoc AST
+-- | A splice to render a Pandoc AST. Emits the document body followed
+-- by a trailing `<ol>` of footnote definitions.
 pandocSplice ::
   RenderCtx ->
   Pandoc ->
   HI.Splice Identity
 pandocSplice ctx doc = do
-  -- Create a new context to render footnote references
+  docNodes <- pandocSpliceWithoutFootnoteList ctx doc
+  footnotesNodes <- renderFootnotesWith ctx (gatherFootnotes doc)
+  pure $ docNodes <> footnotesNodes
+
+{- | Like `pandocSplice` but omits the trailing footnote list.
+
+ Footnote references inside the rendered doc are still wired (each
+ `B.Note` becomes a `<sup>` via the `footnote:*` splices), but no
+ `<ol>` of definitions is emitted at the end.
+
+ Intended for custom block renderers that are themselves invoked from
+ inside an outer `pandocSplice` and that want to render a sub-`Pandoc`
+ (e.g. a callout body) without producing a duplicate footnote listing.
+ The outer `pandocSplice` already walks the full AST via
+ `gatherFootnotes` and emits the document-level list; this function
+ relies on that single list instead of emitting its own.
+-}
+pandocSpliceWithoutFootnoteList ::
+  RenderCtx ->
+  Pandoc ->
+  HI.Splice Identity
+pandocSpliceWithoutFootnoteList ctx doc = do
   let footnotes = gatherFootnotes doc
       docCtx =
         ctx
           { inlineSplice = concatSpliceFunc (inlineSplice ctx) (footnoteRefSplice docCtx footnotes)
           }
-  -- Render main document
-  docNodes <- renderPandocWith docCtx doc
-  -- Render footnotes themselves, but without recursing into inner footnotes.
-  footnotesNodes <- renderFootnotesWith ctx footnotes
-  pure $ docNodes <> footnotesNodes
+  renderPandocWith docCtx doc

--- a/src/Heist/Extra/Splices/Pandoc.hs
+++ b/src/Heist/Extra/Splices/Pandoc.hs
@@ -1,6 +1,12 @@
 module Heist.Extra.Splices.Pandoc (
   RenderCtx (..),
   pandocSplice,
+  -- | Render a `Pandoc` doc /without/ emitting a trailing footnote
+  -- list. Intended for callers nested inside a `pandocSplice` — the
+  -- outer call already gathered every `B.Note` in the AST (including
+  -- inside this callee's input) and will render the document-level
+  -- footnote list, so the inner render must not emit its own copy.
+  renderPandocWith,
   -- | To delegate rendering of blocks and inlines from a custom splice.
   rpBlock,
   rpInline,

--- a/src/Heist/Extra/Splices/Pandoc/Ctx.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Ctx.hs
@@ -67,11 +67,9 @@ data RenderCtx = RenderCtx
     blockSplice :: B.Block -> Maybe (HI.Splice Identity)
   , inlineSplice :: B.Inline -> Maybe (HI.Splice Identity)
   , renderFeatures :: RenderFeatures
-  , -- Prefix for HTML IDs generated during rendering (currently only
-    -- footnote IDs). Empty by default; a non-empty value namespaces IDs
-    -- so that multiple documents rendered into the same page (e.g. via
-    -- note embedding) do not produce duplicate id attributes.
-    idPrefix :: Text
+  , idPrefix :: Text
+  -- ^ Prepended to HTML IDs emitted by rendering, so multiple
+  -- documents on the same page don't collide. Empty by default.
   }
 
 mkRenderCtx ::
@@ -89,19 +87,29 @@ mkRenderCtx classMap bS iS features = do
   node <- H.getParamNode
   let ctx =
         RenderCtx
-          (Just node)
-          (blockLookupAttr node)
-          (inlineLookupAttr node)
-          classMap
-          (bS ctx)
-          (iS ctx)
-          features
-          ""
+          { rootNode = Just node
+          , bAttr = blockLookupAttr node
+          , iAttr = inlineLookupAttr node
+          , classMap = classMap
+          , blockSplice = bS ctx
+          , inlineSplice = iS ctx
+          , renderFeatures = features
+          , idPrefix = ""
+          }
    in pure ctx
 
 emptyRenderCtx :: RenderCtx
 emptyRenderCtx =
-  RenderCtx Nothing (const B.nullAttr) (const B.nullAttr) mempty (const Nothing) (const Nothing) defaultFeatures ""
+  RenderCtx
+    { rootNode = Nothing
+    , bAttr = const B.nullAttr
+    , iAttr = const B.nullAttr
+    , classMap = mempty
+    , blockSplice = const Nothing
+    , inlineSplice = const Nothing
+    , renderFeatures = defaultFeatures
+    , idPrefix = ""
+    }
 
 -- | Strip any custom splicing out of the given render context
 ctxSansCustomSplicing :: RenderCtx -> RenderCtx

--- a/src/Heist/Extra/Splices/Pandoc/Ctx.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Ctx.hs
@@ -67,6 +67,11 @@ data RenderCtx = RenderCtx
     blockSplice :: B.Block -> Maybe (HI.Splice Identity)
   , inlineSplice :: B.Inline -> Maybe (HI.Splice Identity)
   , renderFeatures :: RenderFeatures
+  , -- Prefix for HTML IDs generated during rendering (currently only
+    -- footnote IDs). Empty by default; a non-empty value namespaces IDs
+    -- so that multiple documents rendered into the same page (e.g. via
+    -- note embedding) do not produce duplicate id attributes.
+    idPrefix :: Text
   }
 
 mkRenderCtx ::
@@ -91,11 +96,12 @@ mkRenderCtx classMap bS iS features = do
           (bS ctx)
           (iS ctx)
           features
+          ""
    in pure ctx
 
 emptyRenderCtx :: RenderCtx
 emptyRenderCtx =
-  RenderCtx Nothing (const B.nullAttr) (const B.nullAttr) mempty (const Nothing) (const Nothing) defaultFeatures
+  RenderCtx Nothing (const B.nullAttr) (const B.nullAttr) mempty (const Nothing) (const Nothing) defaultFeatures ""
 
 -- | Strip any custom splicing out of the given render context
 ctxSansCustomSplicing :: RenderCtx -> RenderCtx

--- a/src/Heist/Extra/Splices/Pandoc/Footnotes.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Footnotes.hs
@@ -4,7 +4,7 @@ import Data.List qualified as List
 import Data.Map.Syntax ((##))
 import Heist qualified as H
 import Heist.Extra (runCustomNode)
-import Heist.Extra.Splices.Pandoc.Ctx (RenderCtx (rootNode))
+import Heist.Extra.Splices.Pandoc.Ctx (RenderCtx (idPrefix, rootNode))
 import Heist.Extra.Splices.Pandoc.Render (renderPandocWith)
 import Heist.Interpreted qualified as HI
 import Text.Pandoc.Builder qualified as B
@@ -49,6 +49,11 @@ footnoteSplices ctx idx bs = do
         _ ->
           bs
   "footnote:idx" ## HI.textSplice (show idx)
+  -- HTML-id-friendly variant: the caller's `idPrefix` prepended. Use
+  -- this (not `footnote:idx`) for `id="fn…"` / `id="fnref…"` and for
+  -- the matching `href` fragments, so that nested `pandocSplice` calls
+  -- (e.g. embedded notes) don't collide.
+  "footnote:id" ## HI.textSplice (idPrefix ctx <> show idx)
   "footnote:content" ## renderPandocWith ctx footnoteDoc
 
 footnoteRefSplice :: RenderCtx -> [[B.Block]] -> B.Inline -> Maybe (HI.Splice Identity)

--- a/src/Heist/Extra/Splices/Pandoc/Footnotes.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Footnotes.hs
@@ -48,12 +48,9 @@ footnoteSplices ctx idx bs = do
           one $ B.Plain is
         _ ->
           bs
-  "footnote:idx" ## HI.textSplice (show idx)
-  -- HTML-id-friendly variant: the caller's `idPrefix` prepended. Use
-  -- this (not `footnote:idx`) for `id="fn…"` / `id="fnref…"` and for
-  -- the matching `href` fragments, so that nested `pandocSplice` calls
-  -- (e.g. embedded notes) don't collide.
-  "footnote:id" ## HI.textSplice (idPrefix ctx <> show idx)
+  let idxText = show idx
+  "footnote:idx" ## HI.textSplice idxText
+  "footnote:id" ## HI.textSplice (idPrefix ctx <> idxText)
   "footnote:content" ## renderPandocWith ctx footnoteDoc
 
 footnoteRefSplice :: RenderCtx -> [[B.Block]] -> B.Inline -> Maybe (HI.Splice Identity)


### PR DESCRIPTION
**A consumer rendering multiple pandoc documents into a single page has no way, today, to prevent their footnote ids from colliding.** `pandocSplice` numbers footnotes from 1 per document, and the generated `id="fn1"` / `id="fnref1"` attributes are baked straight into the emitted HTML. That's fine for a standalone page, but the moment two documents land on the same page — Emanote's note-embed is the motivating case (see [srid/emanote#360](https://github.com/srid/emanote/issues/360)) — you get duplicate ids that browsers can't disambiguate.

This adds a single knob: **`RenderCtx.idPrefix :: Text`**, default `""`. A new `footnote:id` splice emits `prefix <> show idx`, intended for `id="fn…"` / `id="fnref…"` attributes and matching `href` fragments. The visible `${footnote:idx}` digit is unchanged — templates keep showing ¹ ² ³ to readers. *Unprefixed callers see no behavioural difference: `idPrefix = ""` means `footnote:id` reduces to `show idx`, which is what the old template expected.* The consumer decides when and how to set the prefix; the library only provides the mechanism.

`mkRenderCtx` and `emptyRenderCtx` switch to named-field syntax while we're here, since an 8-field positional constructor was already past the threshold where a stray reordering compiles silently.

Version bump **0.5.0.0 → 0.5.1.0**.

Paired with the first consumer: [srid/emanote#640](https://github.com/srid/emanote/pull/640).