### PR TITLE
Wrap raw HTML in unique <rawhtml> element to dodge xmlhtml's div check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add syntax highlighting for code blocks using skylighting (#10)
 - Remove prism.js `language-*` class hack (no longer needed with static highlighting)
 - Add static math rendering for `$...$` and `$$...$$` via `texmath` (LaTeX → MathML at build time)
-- Wrap raw HTML/inline blobs in a unique `<rawhtml>` element (with `display: contents`) instead of `<div>`/`<span>` (#13). Avoids xmlhtml's "div cannot contain text looking like its end tag" crash when raw HTML contains a literal `</div>` — most painfully, mermaid SVG with `<foreignObject><div>…</div>` HTML labels. Fixes srid/emanote#119.
+- Wrap raw HTML/inline blobs in a unique `<rawhtml>` element (with `display: contents`) instead of `<div>`/`<span>` ([#13](https://github.com/srid/heist-extra/pull/13)). Avoids xmlhtml's "div cannot contain text looking like its end tag" crash when raw HTML contains a literal `</div>` — most painfully, mermaid SVG with `<foreignObject><div>…</div>` HTML labels. Fixes [srid/emanote#119](https://github.com/srid/emanote/issues/119).
 
 ## 0.4.0.0 (2025-08-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add syntax highlighting for code blocks using skylighting (#10)
 - Remove prism.js `language-*` class hack (no longer needed with static highlighting)
 - Add static math rendering for `$...$` and `$$...$$` via `texmath` (LaTeX → MathML at build time)
+- Wrap raw HTML/inline blobs in a unique `<rawhtml>` element (with `display: contents`) instead of `<div>`/`<span>` (#13). Avoids xmlhtml's "div cannot contain text looking like its end tag" crash when raw HTML contains a literal `</div>` — most painfully, mermaid SVG with `<foreignObject><div>…</div>` HTML labels. Fixes srid/emanote#119.
 
 ## 0.4.0.0 (2025-08-19)
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+tests: True

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,4 @@
-packages: .
+packages:
+  .
+
 tests: True

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
           packages = {
             pandoc-types.source = "1.23";
           };
+          devShell.tools = hp: { inherit (hp) hspec-discover; };
           autoWire = [ "packages" "checks" ];
         };
 

--- a/heist-extra.cabal
+++ b/heist-extra.cabal
@@ -105,3 +105,20 @@ library
     Heist.Extra.Splices.Pandoc.Texmath
     Heist.Extra.Splices.Tree
     Heist.Extra.TemplateState
+
+test-suite test
+  type:               exitcode-stdio-1.0
+  hs-source-dirs:     test
+  main-is:            Spec.hs
+  other-modules:      Heist.Extra.Splices.Pandoc.RenderSpec
+  default-language:   Haskell2010
+  default-extensions: ImportQualifiedPost OverloadedStrings
+  ghc-options:        -Wall
+  build-depends:
+    , base
+    , blaze-builder
+    , bytestring
+    , heist-extra
+    , hspec
+    , text
+    , xmlhtml

--- a/src/Heist/Extra/Splices/Pandoc/Render.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Render.hs
@@ -6,6 +6,9 @@ module Heist.Extra.Splices.Pandoc.Render (
   rpInline,
   rpBlock',
   rpInline',
+
+  -- * Internal helpers (exported for tests)
+  rawNode,
 ) where
 
 import Data.Map.Strict qualified as Map

--- a/src/Heist/Extra/Splices/Pandoc/Render.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Render.hs
@@ -296,11 +296,26 @@ rpTask ctx is default_ =
         ("inlines" ## rpInline ctx `foldMapM` taskInlines)
         default_
 
+{- | Wrap a raw HTML/inline blob in a Heist-internal element so xmlhtml's
+parser keeps the bytes opaque (via the @xmlhtmlRaw@ marker attribute) and
+the renderer emits them verbatim.
+
+The wrapper tag is a fixed @rawhtml@ regardless of caller intent: xmlhtml's
+@Render.hs:131-133@ check fires if a raw-text element's text content
+contains @</tagName@, so wrapping in @\<div\>@ blows up on any embedded
+HTML that includes a closing @\</div\>@ — most painfully, mermaid's SVG
+ships HTML labels inside @\<foreignObject\>@. A single dedicated tag
+name avoids the collision once and for all. @display: contents@ collapses
+the wrapper so it doesn't disturb the surrounding flow layout.
+-}
 rawNode :: Text -> Text -> [X.Node]
-rawNode wrapperTag s =
-  one . X.Element wrapperTag (one ("xmlhtmlRaw", "")) $
-    one . X.TextNode $
-      s
+rawNode _wrapperTag s =
+  one
+    . X.Element
+      "rawhtml"
+      [("xmlhtmlRaw", ""), ("style", "display: contents")]
+    $ one . X.TextNode
+    $ s
 
 -- | Emit raw LaTeX wrapped in a span for client-side rendering (KaTeX/MathJax).
 renderMathPassthrough :: B.MathType -> Text -> [X.Node]

--- a/test/Heist/Extra/Splices/Pandoc/RenderSpec.hs
+++ b/test/Heist/Extra/Splices/Pandoc/RenderSpec.hs
@@ -1,0 +1,77 @@
+-- | Tests for "Heist.Extra.Splices.Pandoc.Render".
+module Heist.Extra.Splices.Pandoc.RenderSpec (spec) where
+
+import Blaze.ByteString.Builder (toByteString)
+import Control.Exception (evaluate)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Text (Text)
+import Data.Text.Encoding (encodeUtf8)
+import Heist.Extra.Splices.Pandoc.Render (rawNode)
+import Prelude
+import Test.Hspec
+import Text.XmlHtml qualified as X
+
+-- | Force-render a node tree to bytes via xmlhtml's HTML5 fragment renderer.
+-- Any `error` thrown by the renderer surfaces here.
+renderHtml :: [X.Node] -> IO ByteString
+renderHtml = evaluate . toByteString . X.renderHtmlFragment X.UTF8
+
+spec :: Spec
+spec = do
+  describe "rawNode" $ do
+    it "wraps content in a <rawhtml> element" $ do
+      case rawNode "div" "<svg/>" of
+        [X.Element name _ _] -> name `shouldBe` "rawhtml"
+        ns -> expectationFailure $ "expected single Element; got " <> show ns
+
+    it "ignores the wrapperTag argument (always emits <rawhtml>)" $ do
+      let blockNodes = rawNode "div" "x"
+          inlineNodes = rawNode "span" "x"
+      blockNodes `shouldBe` inlineNodes
+
+    it "carries the xmlhtmlRaw marker so xmlhtml treats content as opaque" $ do
+      case rawNode "div" "<svg/>" of
+        [X.Element _ attrs _] ->
+          lookup "xmlhtmlRaw" attrs `shouldBe` Just ""
+        _ -> expectationFailure "expected single Element"
+
+    it "applies display: contents inline so the wrapper is layout-invisible" $ do
+      case rawNode "div" "<svg/>" of
+        [X.Element _ attrs _] ->
+          lookup "style" attrs `shouldBe` Just "display: contents"
+        _ -> expectationFailure "expected single Element"
+
+    it "passes the body through as a single TextNode (no parsing)" $ do
+      let body = "<svg><foreignObject><div>x</div></foreignObject></svg>"
+      case rawNode "div" body of
+        [X.Element _ _ [X.TextNode t]] -> t `shouldBe` body
+        ns -> expectationFailure $ "expected one TextNode child; got " <> show ns
+
+  describe "rawNode + xmlhtml render (regression: srid/emanote#119, #625)" $ do
+    -- The whole point of switching from <div xmlhtmlRaw> to <rawhtml>: a body
+    -- that contains </div> used to crash xmlhtml's renderer at HTML/Render.hs:131
+    -- with "div cannot contain text looking like its end tag". With the new
+    -- wrapper that check is checking for "</rawhtml" instead, which never
+    -- appears in real HTML/SVG content.
+    it "renders a body containing </div> without throwing" $ do
+      let body = "<details><div>x</div></details>" :: Text
+      out <- renderHtml (rawNode "div" body)
+      out `shouldSatisfy` (encodeUtf8 body `BS.isInfixOf`)
+
+    it "renders a body containing </span> without throwing (inline path)" $ do
+      let body = "<span>a</span><span>b</span>" :: Text
+      out <- renderHtml (rawNode "span" body)
+      out `shouldSatisfy` (encodeUtf8 body `BS.isInfixOf`)
+
+    it "renders a mermaid-shaped SVG body without throwing" $ do
+      -- Shape mirrors mmdc's actual output: outer <svg> with inner
+      -- <foreignObject><div>...</div></foreignObject> HTML labels. The </div>
+      -- inside foreignObject is what tripped the old wrapper.
+      let body =
+            "<svg xmlns=\"http://www.w3.org/2000/svg\">\
+            \<foreignObject><div xmlns=\"http://www.w3.org/1999/xhtml\">\
+            \<span>label</span></div></foreignObject></svg>" :: Text
+      out <- renderHtml (rawNode "div" body)
+      out `shouldSatisfy` ("<foreignObject>" `BS.isInfixOf`)
+      out `shouldSatisfy` ("</div>" `BS.isInfixOf`)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,8 @@
+module Main (main) where
+
+import Heist.Extra.Splices.Pandoc.RenderSpec qualified as RenderSpec
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec $ do
+  RenderSpec.spec


### PR DESCRIPTION
xmlhtml's `Text.XmlHtml.HTML.Render` at lines 131-133 errors with `<tag> cannot contain text looking like its end tag` whenever a raw-text element's text content contains `</tagName`. Wrapping arbitrary raw HTML in `<div xmlhtmlRaw>` therefore **blows up the moment that HTML contains a literal `</div>`** — which mermaid's SVG output always does, since it ships HTML labels via `<foreignObject><div xmlns="http://www.w3.org/1999/xhtml">…</div></foreignObject>`.

`rawNode` now always wraps in a fixed `<rawhtml>` element regardless of the caller-supplied `wrapperTag` (kept for API compat, marked unused). The tag won't appear inside any embedded HTML/SVG content, and an inline `style="display: contents"` collapses the wrapper so the surrounding flow layout is untouched.

### Bugs this fixes

- [srid/emanote#119](https://github.com/srid/emanote/issues/119) — `<div></div>` in raw HTML blocks crashes the renderer with the exact same error message.
- [srid/emanote#625](https://github.com/srid/emanote/issues/625) — mermaid → inline SVG path crashes on every diagram with HTML labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)