### PR TITLE
Apply Pandoc table colSpec / cell metadata when rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Remove prism.js `language-*` class hack (no longer needed with static highlighting)
 - Add static math rendering for `$...$` and `$$...$$` via `texmath` (LaTeX → MathML at build time)
 - Wrap raw HTML/inline blobs in a unique `<rawhtml>` element (with `display: contents`) instead of `<div>`/`<span>` ([#13](https://github.com/srid/heist-extra/pull/13)). Avoids xmlhtml's "div cannot contain text looking like its end tag" crash when raw HTML contains a literal `</div>` — most painfully, mermaid SVG with `<foreignObject><div>…</div>` HTML labels. Fixes [srid/emanote#119](https://github.com/srid/emanote/issues/119).
+- Pandoc `Table` rendering now applies the AST fields it had been silently dropping ([#15](https://github.com/srid/heist-extra/pull/15)): per-column alignment from `ColSpec` (with cell-level `Alignment` overriding the column default), column widths via a generated `<colgroup>`, cell `RowSpan`/`ColSpan` as `rowspan`/`colspan` attributes, row & cell `Attr` merged into the rendered `<tr>`/`<th>`/`<td>`, and `TableFoot` rows rendered into `<tfoot>`. Captions are still skipped — commonmark-hs doesn't emit them. Pure helpers (`alignmentStyle`, `colSpecsToColgroup`, `cellSpanAttrs`, `cellColumnIndices`, `mergeStyleKVs`) live in the new `Heist.Extra.Splices.Pandoc.Render.Internal` module so consumers get a clean public API. Fixes [srid/emanote#27](https://github.com/srid/emanote/issues/27).
 
 ## 0.4.0.0 (2025-08-19)
 

--- a/heist-extra.cabal
+++ b/heist-extra.cabal
@@ -118,6 +118,7 @@ test-suite test
     , base
     , blaze-builder
     , bytestring
+    , heist
     , heist-extra
     , hspec
     , pandoc-types

--- a/heist-extra.cabal
+++ b/heist-extra.cabal
@@ -100,6 +100,7 @@ library
     Heist.Extra.Splices.Pandoc.Ctx
     Heist.Extra.Splices.Pandoc.Footnotes
     Heist.Extra.Splices.Pandoc.Render
+    Heist.Extra.Splices.Pandoc.Render.Internal
     Heist.Extra.Splices.Pandoc.Skylighting
     Heist.Extra.Splices.Pandoc.TaskList
     Heist.Extra.Splices.Pandoc.Texmath

--- a/heist-extra.cabal
+++ b/heist-extra.cabal
@@ -120,5 +120,6 @@ test-suite test
     , bytestring
     , heist-extra
     , hspec
+    , pandoc-types
     , text
     , xmlhtml

--- a/src/Heist/Extra/Splices/Pandoc/Render.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Render.hs
@@ -12,6 +12,7 @@ module Heist.Extra.Splices.Pandoc.Render (
   alignmentStyle,
   colSpecsToColgroup,
   cellSpanAttrs,
+  cellColumnIndices,
 ) where
 
 import Data.Map.Strict qualified as Map
@@ -128,7 +129,10 @@ rpBlock' ctx@RenderCtx {..} b = case b of
               merged = concatAttr (concatAttr cAttr cellTwAttr) ("", mempty, extraKVs)
           one . X.Element tag (rpAttr merged) <$> foldMapM (rpBlock ctx) blks
         renderRow tag (B.Row rAttr cells) = do
-          rendered <- fold <$> zipWithM (renderCell tag) [0 ..] cells
+          -- Cell *position* in the row and column *index* diverge as soon as
+          -- any cell has ColSpan > 1; resolving alignment by zip-position
+          -- would silently misfire across a merged cell.
+          rendered <- fold <$> zipWithM (renderCell tag) (cellColumnIndices cells) cells
           pure $ one $ X.Element "tr" (rpAttr (concatAttr rAttr rowTwAttr)) rendered
         wrapSection tag cellTag rows
           | null rows = pure mempty
@@ -379,6 +383,18 @@ cellSpanAttrs (B.RowSpan rs) (B.ColSpan cs) =
     [ guard (rs > 1) $> ("rowspan", show rs)
     , guard (cs > 1) $> ("colspan", show cs)
     ]
+
+{- | The starting column index of every cell in a row, accounting for
+ 'B.ColSpan'. A cell that spans /n/ columns occupies indices
+ @[i .. i+n-1]@; the next cell starts at @i+n@. Resolving column
+ alignment by simple list position would silently misalign cells
+ whenever a row contains a merged cell.
+-}
+cellColumnIndices :: [B.Cell] -> [Int]
+cellColumnIndices = go 0
+  where
+    go _ [] = []
+    go col (B.Cell _ _ _ (B.ColSpan cs) _ : rest) = col : go (col + cs) rest
 
 -- | Convert Pandoc AST inlines to raw text.
 plainify :: [B.Inline] -> Text

--- a/src/Heist/Extra/Splices/Pandoc/Render.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Render.hs
@@ -118,20 +118,14 @@ rpBlock' ctx@RenderCtx {..} b = case b of
         cellTwAttr = ("", ["py-2", "px-2", "align-top", "border-r-2", "border-l-2", borderStyle], mempty)
         tableAttr = ("", ["mb-3"], mempty)
         colAligns = fst <$> colSpecs
-        colAlignAt i = case drop i colAligns of
-          a : _ -> a
-          [] -> B.AlignDefault
         renderCell tag i (B.Cell cAttr cAlign rspan cspan blks) = do
           let effectiveAlign = case cAlign of
-                B.AlignDefault -> colAlignAt i
+                B.AlignDefault -> fromMaybe B.AlignDefault (colAligns !!? i)
                 a -> a
               extraKVs = catMaybes [alignmentStyle effectiveAlign] <> cellSpanAttrs rspan cspan
               merged = concatAttr (concatAttr cAttr cellTwAttr) ("", mempty, extraKVs)
           one . X.Element tag (rpAttr merged) <$> foldMapM (rpBlock ctx) blks
         renderRow tag (B.Row rAttr cells) = do
-          -- Cell *position* in the row and column *index* diverge as soon as
-          -- any cell has ColSpan > 1; resolving alignment by zip-position
-          -- would silently misfire across a merged cell.
           rendered <- fold <$> zipWithM (renderCell tag) (cellColumnIndices cells) cells
           pure $ one $ X.Element "tr" (rpAttr (concatAttr rAttr rowTwAttr)) rendered
         wrapSection tag cellTag rows
@@ -139,10 +133,9 @@ rpBlock' ctx@RenderCtx {..} b = case b of
           | otherwise = one . X.Element tag mempty <$> foldMapM (renderRow cellTag) rows
     fmap (one . X.Element "table" (rpAttr $ concatAttr attr tableAttr)) $ do
       let cg = colSpecsToColgroup colSpecs
+          bodyRows = concatMap (\(B.TableBody _ _ _ rs) -> rs) tbodys
       thead <- wrapSection "thead" "th" hrows
-      tbody <- fmap (one . X.Element "tbody" mempty) $
-        flip foldMapM tbodys $ \(B.TableBody _ _ _ rows) ->
-          foldMapM (renderRow "td") rows
+      tbody <- wrapSection "tbody" "td" bodyRows
       tfoot <- wrapSection "tfoot" "td" frows
       pure $ cg <> thead <> tbody <> tfoot
   B.Div attr bs ->
@@ -348,10 +341,8 @@ renderMathPassthrough mathType s =
       B.InlineMath -> ("math inline", "\\(" <> s <> "\\)")
       B.DisplayMath -> ("math display", "$$" <> s <> "$$")
 
-{- | Render the per-column @text-align@ inline style for a Pandoc
- 'B.Alignment'. 'B.AlignDefault' yields 'Nothing' so the attribute is
- omitted entirely instead of inheriting the user agent's default
- explicitly.
+{- | 'B.AlignDefault' yields 'Nothing' so the attribute is omitted entirely
+ rather than emitting an inline style that re-asserts the user-agent default.
 -}
 alignmentStyle :: B.Alignment -> Maybe (Text, Text)
 alignmentStyle = \case
@@ -360,9 +351,8 @@ alignmentStyle = \case
   B.AlignCenter -> Just ("style", "text-align: center")
   B.AlignDefault -> Nothing
 
-{- | Build a @\<colgroup\>@ from Pandoc 'B.ColSpec' widths. Returns an
- empty list when every column width is 'B.ColWidthDefault' so we don't
- emit a noise-only element.
+{- | Returns the empty list when every width is 'B.ColWidthDefault' — a
+ @\<colgroup\>@ full of bare @\<col\>@s would just be HTML noise.
 -}
 colSpecsToColgroup :: [B.ColSpec] -> [X.Node]
 colSpecsToColgroup specs
@@ -374,9 +364,7 @@ colSpecsToColgroup specs
       X.Element "col" [("style", "width: " <> percent w)] mempty
     percent w = T.pack (showFFloat (Just 2) (w * 100) "") <> "%"
 
-{- | HTML @rowspan@ / @colspan@ attribute pairs for spans greater than 1.
- Spans of 1 are the HTML default and are omitted.
--}
+-- | Spans of 1 are the HTML default and are omitted to avoid noise.
 cellSpanAttrs :: B.RowSpan -> B.ColSpan -> [(Text, Text)]
 cellSpanAttrs (B.RowSpan rs) (B.ColSpan cs) =
   catMaybes
@@ -384,11 +372,9 @@ cellSpanAttrs (B.RowSpan rs) (B.ColSpan cs) =
     , guard (cs > 1) $> ("colspan", show cs)
     ]
 
-{- | The starting column index of every cell in a row, accounting for
- 'B.ColSpan'. A cell that spans /n/ columns occupies indices
- @[i .. i+n-1]@; the next cell starts at @i+n@. Resolving column
- alignment by simple list position would silently misalign cells
- whenever a row contains a merged cell.
+{- | A cell with @ColSpan n@ occupies indices @[i .. i+n-1]@, so the next
+ cell starts at @i+n@; zipping by list position would silently misalign
+ every cell after a merged one.
 -}
 cellColumnIndices :: [B.Cell] -> [Int]
 cellColumnIndices = go 0

--- a/src/Heist/Extra/Splices/Pandoc/Render.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Render.hs
@@ -13,8 +13,10 @@ module Heist.Extra.Splices.Pandoc.Render (
   colSpecsToColgroup,
   cellSpanAttrs,
   cellColumnIndices,
+  mergeStyleKVs,
 ) where
 
+import Data.List (partition)
 import Data.Map.Strict qualified as Map
 import Data.Map.Syntax ((##))
 import Data.Text qualified as T
@@ -123,8 +125,12 @@ rpBlock' ctx@RenderCtx {..} b = case b of
                 B.AlignDefault -> fromMaybe B.AlignDefault (colAligns !!? i)
                 a -> a
               extraKVs = catMaybes [alignmentStyle effectiveAlign] <> cellSpanAttrs rspan cspan
-              merged = concatAttr (concatAttr cAttr cellTwAttr) ("", mempty, extraKVs)
-          one . X.Element tag (rpAttr merged) <$> foldMapM (rpBlock ctx) blks
+              -- A raw-HTML cell could carry its own `style`; concatAttr would
+              -- list-append, leaving two `style` attrs on one element (invalid
+              -- HTML; later browsers silently drop one). Consolidate via
+              -- semicolon join instead.
+              cellKVs = mergeStyleKVs (rpAttr (concatAttr cAttr cellTwAttr)) extraKVs
+          one . X.Element tag cellKVs <$> foldMapM (rpBlock ctx) blks
         renderRow tag (B.Row rAttr cells) = do
           rendered <- fold <$> zipWithM (renderCell tag) (cellColumnIndices cells) cells
           pure $ one $ X.Element "tr" (rpAttr (concatAttr rAttr rowTwAttr)) rendered
@@ -381,6 +387,20 @@ cellColumnIndices = go 0
   where
     go _ [] = []
     go col (B.Cell _ _ _ (B.ColSpan cs) _ : rest) = col : go (col + cs) rest
+
+{- | Append @right@ onto @left@, but consolidate any duplicate @style@ keys
+ into one entry joined with @"; "@. xmlhtml passes attributes through
+ verbatim, so two @style@ entries reach the browser as two attributes on
+ one element — invalid HTML, with the later value silently dropped by
+ most engines.
+-}
+mergeStyleKVs :: [(Text, Text)] -> [(Text, Text)] -> [(Text, Text)]
+mergeStyleKVs left right =
+  let (styles, rest) = partition ((== "style") . fst) (left <> right)
+   in case styles of
+        [] -> rest
+        [single] -> rest <> [single]
+        multiple -> rest <> [("style", T.intercalate "; " (snd <$> multiple))]
 
 -- | Convert Pandoc AST inlines to raw text.
 plainify :: [B.Inline] -> Text

--- a/src/Heist/Extra/Splices/Pandoc/Render.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Render.hs
@@ -7,16 +7,10 @@ module Heist.Extra.Splices.Pandoc.Render (
   rpBlock',
   rpInline',
 
-  -- * Internal helpers (exported for tests)
+  -- * Exported for tests
   rawNode,
-  alignmentStyle,
-  colSpecsToColgroup,
-  cellSpanAttrs,
-  cellColumnIndices,
-  mergeStyleKVs,
 ) where
 
-import Data.List (partition)
 import Data.Map.Strict qualified as Map
 import Data.Map.Syntax ((##))
 import Data.Text qualified as T
@@ -30,11 +24,17 @@ import Heist.Extra.Splices.Pandoc.Ctx (
   RenderFeatures (..),
   rewriteClass,
  )
+import Heist.Extra.Splices.Pandoc.Render.Internal (
+  alignmentStyle,
+  cellColumnIndices,
+  cellSpanAttrs,
+  colSpecsToColgroup,
+  mergeStyleKVs,
+ )
 import Heist.Extra.Splices.Pandoc.Skylighting (highlightCode)
 import Heist.Extra.Splices.Pandoc.TaskList qualified as TaskList
 import Heist.Extra.Splices.Pandoc.Texmath (renderMath)
 import Heist.Interpreted qualified as HI
-import Numeric (showFFloat)
 import Text.Pandoc.Builder qualified as B
 import Text.Pandoc.Definition (Pandoc (..))
 import Text.Pandoc.Walk as W
@@ -346,61 +346,6 @@ renderMathPassthrough mathType s =
     (klass, wrapped) = case mathType of
       B.InlineMath -> ("math inline", "\\(" <> s <> "\\)")
       B.DisplayMath -> ("math display", "$$" <> s <> "$$")
-
-{- | 'B.AlignDefault' yields 'Nothing' so the attribute is omitted entirely
- rather than emitting an inline style that re-asserts the user-agent default.
--}
-alignmentStyle :: B.Alignment -> Maybe (Text, Text)
-alignmentStyle = \case
-  B.AlignLeft -> Just ("style", "text-align: left")
-  B.AlignRight -> Just ("style", "text-align: right")
-  B.AlignCenter -> Just ("style", "text-align: center")
-  B.AlignDefault -> Nothing
-
-{- | Returns the empty list when every width is 'B.ColWidthDefault' — a
- @\<colgroup\>@ full of bare @\<col\>@s would just be HTML noise.
--}
-colSpecsToColgroup :: [B.ColSpec] -> [X.Node]
-colSpecsToColgroup specs
-  | all ((== B.ColWidthDefault) . snd) specs = mempty
-  | otherwise = one $ X.Element "colgroup" mempty (renderCol <$> specs)
-  where
-    renderCol (_, B.ColWidthDefault) = X.Element "col" mempty mempty
-    renderCol (_, B.ColWidth w) =
-      X.Element "col" [("style", "width: " <> percent w)] mempty
-    percent w = T.pack (showFFloat (Just 2) (w * 100) "") <> "%"
-
--- | Spans of 1 are the HTML default and are omitted to avoid noise.
-cellSpanAttrs :: B.RowSpan -> B.ColSpan -> [(Text, Text)]
-cellSpanAttrs (B.RowSpan rs) (B.ColSpan cs) =
-  catMaybes
-    [ guard (rs > 1) $> ("rowspan", show rs)
-    , guard (cs > 1) $> ("colspan", show cs)
-    ]
-
-{- | A cell with @ColSpan n@ occupies indices @[i .. i+n-1]@, so the next
- cell starts at @i+n@; zipping by list position would silently misalign
- every cell after a merged one.
--}
-cellColumnIndices :: [B.Cell] -> [Int]
-cellColumnIndices = go 0
-  where
-    go _ [] = []
-    go col (B.Cell _ _ _ (B.ColSpan cs) _ : rest) = col : go (col + cs) rest
-
-{- | Append @right@ onto @left@, but consolidate any duplicate @style@ keys
- into one entry joined with @"; "@. xmlhtml passes attributes through
- verbatim, so two @style@ entries reach the browser as two attributes on
- one element — invalid HTML, with the later value silently dropped by
- most engines.
--}
-mergeStyleKVs :: [(Text, Text)] -> [(Text, Text)] -> [(Text, Text)]
-mergeStyleKVs left right =
-  let (styles, rest) = partition ((== "style") . fst) (left <> right)
-   in case styles of
-        [] -> rest
-        [single] -> rest <> [single]
-        multiple -> rest <> [("style", T.intercalate "; " (snd <$> multiple))]
 
 -- | Convert Pandoc AST inlines to raw text.
 plainify :: [B.Inline] -> Text

--- a/src/Heist/Extra/Splices/Pandoc/Render.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Render.hs
@@ -9,6 +9,9 @@ module Heist.Extra.Splices.Pandoc.Render (
 
   -- * Internal helpers (exported for tests)
   rawNode,
+  alignmentStyle,
+  colSpecsToColgroup,
+  cellSpanAttrs,
 ) where
 
 import Data.Map.Strict qualified as Map
@@ -28,6 +31,7 @@ import Heist.Extra.Splices.Pandoc.Skylighting (highlightCode)
 import Heist.Extra.Splices.Pandoc.TaskList qualified as TaskList
 import Heist.Extra.Splices.Pandoc.Texmath (renderMath)
 import Heist.Interpreted qualified as HI
+import Numeric (showFFloat)
 import Text.Pandoc.Builder qualified as B
 import Text.Pandoc.Definition (Pandoc (..))
 import Text.Pandoc.Walk as W
@@ -106,26 +110,37 @@ rpBlock' ctx@RenderCtx {..} b = case b of
         <$> innerSplice
   B.HorizontalRule ->
     withTplTag ctx "HorizontalRule" mempty (pure $ one $ X.Element "hr" mempty mempty)
-  B.Table attr _captions _colSpec (B.TableHead _ hrows) tbodys _tfoot -> do
+  B.Table attr _captions colSpecs (B.TableHead _ hrows) tbodys (B.TableFoot _ frows) -> do
     -- TODO: Move tailwind styles to pandoc.tpl
     let borderStyle = "border-gray-300"
-        rowStyle = [("class", "border-b-2 border-t-2 " <> borderStyle)]
-        cellStyle = [("class", "py-2 px-2 align-top border-r-2 border-l-2 " <> borderStyle)]
+        rowTwAttr = ("", ["border-b-2", "border-t-2", borderStyle], mempty)
+        cellTwAttr = ("", ["py-2", "px-2", "align-top", "border-r-2", "border-l-2", borderStyle], mempty)
         tableAttr = ("", ["mb-3"], mempty)
-    -- TODO: Apply captions, colSpec, etc.
+        colAligns = fst <$> colSpecs
+        colAlignAt i = case drop i colAligns of
+          a : _ -> a
+          [] -> B.AlignDefault
+        renderCell tag i (B.Cell cAttr cAlign rspan cspan blks) = do
+          let effectiveAlign = case cAlign of
+                B.AlignDefault -> colAlignAt i
+                a -> a
+              extraKVs = catMaybes [alignmentStyle effectiveAlign] <> cellSpanAttrs rspan cspan
+              merged = concatAttr (concatAttr cAttr cellTwAttr) ("", mempty, extraKVs)
+          one . X.Element tag (rpAttr merged) <$> foldMapM (rpBlock ctx) blks
+        renderRow tag (B.Row rAttr cells) = do
+          rendered <- fold <$> zipWithM (renderCell tag) [0 ..] cells
+          pure $ one $ X.Element "tr" (rpAttr (concatAttr rAttr rowTwAttr)) rendered
+        wrapSection tag cellTag rows
+          | null rows = pure mempty
+          | otherwise = one . X.Element tag mempty <$> foldMapM (renderRow cellTag) rows
     fmap (one . X.Element "table" (rpAttr $ concatAttr attr tableAttr)) $ do
-      thead <- fmap (one . X.Element "thead" mempty) $
-        flip foldMapM hrows $ \(B.Row _ cells) ->
-          fmap (one . X.Element "tr" rowStyle) $
-            flip foldMapM cells $ \(B.Cell _ _ _ _ blks) ->
-              one . X.Element "th" cellStyle <$> foldMapM (rpBlock ctx) blks
+      let cg = colSpecsToColgroup colSpecs
+      thead <- wrapSection "thead" "th" hrows
       tbody <- fmap (one . X.Element "tbody" mempty) $
         flip foldMapM tbodys $ \(B.TableBody _ _ _ rows) ->
-          flip foldMapM rows $ \(B.Row _ cells) ->
-            fmap (one . X.Element "tr" rowStyle) $
-              flip foldMapM cells $ \(B.Cell _ _ _ _ blks) ->
-                one . X.Element "td" cellStyle <$> foldMapM (rpBlock ctx) blks
-      pure $ thead <> tbody
+          foldMapM (renderRow "td") rows
+      tfoot <- wrapSection "tfoot" "td" frows
+      pure $ cg <> thead <> tbody <> tfoot
   B.Div attr bs ->
     one . X.Element (getTag "div" attr) (rpAttr $ rewriteClass ctx attr)
       <$> foldMapM (rpBlock ctx) bs
@@ -328,6 +343,42 @@ renderMathPassthrough mathType s =
     (klass, wrapped) = case mathType of
       B.InlineMath -> ("math inline", "\\(" <> s <> "\\)")
       B.DisplayMath -> ("math display", "$$" <> s <> "$$")
+
+{- | Render the per-column @text-align@ inline style for a Pandoc
+ 'B.Alignment'. 'B.AlignDefault' yields 'Nothing' so the attribute is
+ omitted entirely instead of inheriting the user agent's default
+ explicitly.
+-}
+alignmentStyle :: B.Alignment -> Maybe (Text, Text)
+alignmentStyle = \case
+  B.AlignLeft -> Just ("style", "text-align: left")
+  B.AlignRight -> Just ("style", "text-align: right")
+  B.AlignCenter -> Just ("style", "text-align: center")
+  B.AlignDefault -> Nothing
+
+{- | Build a @\<colgroup\>@ from Pandoc 'B.ColSpec' widths. Returns an
+ empty list when every column width is 'B.ColWidthDefault' so we don't
+ emit a noise-only element.
+-}
+colSpecsToColgroup :: [B.ColSpec] -> [X.Node]
+colSpecsToColgroup specs
+  | all ((== B.ColWidthDefault) . snd) specs = mempty
+  | otherwise = one $ X.Element "colgroup" mempty (renderCol <$> specs)
+  where
+    renderCol (_, B.ColWidthDefault) = X.Element "col" mempty mempty
+    renderCol (_, B.ColWidth w) =
+      X.Element "col" [("style", "width: " <> percent w)] mempty
+    percent w = T.pack (showFFloat (Just 2) (w * 100) "") <> "%"
+
+{- | HTML @rowspan@ / @colspan@ attribute pairs for spans greater than 1.
+ Spans of 1 are the HTML default and are omitted.
+-}
+cellSpanAttrs :: B.RowSpan -> B.ColSpan -> [(Text, Text)]
+cellSpanAttrs (B.RowSpan rs) (B.ColSpan cs) =
+  catMaybes
+    [ guard (rs > 1) $> ("rowspan", show rs)
+    , guard (cs > 1) $> ("colspan", show cs)
+    ]
 
 -- | Convert Pandoc AST inlines to raw text.
 plainify :: [B.Inline] -> Text

--- a/src/Heist/Extra/Splices/Pandoc/Render/Internal.hs
+++ b/src/Heist/Extra/Splices/Pandoc/Render/Internal.hs
@@ -1,0 +1,73 @@
+{- | Pure helpers powering the Pandoc 'Text.Pandoc.Definition.Table' arm of
+ "Heist.Extra.Splices.Pandoc.Render". Exposed so the unit suite can pin
+ their behaviour without standing up a Heist splice context. Not part of
+ the library's public surface — import at your own risk.
+-}
+module Heist.Extra.Splices.Pandoc.Render.Internal (
+  alignmentStyle,
+  colSpecsToColgroup,
+  cellSpanAttrs,
+  cellColumnIndices,
+  mergeStyleKVs,
+) where
+
+import Data.List (partition)
+import Data.Text qualified as T
+import Numeric (showFFloat)
+import Text.Pandoc.Definition qualified as B
+import Text.XmlHtml qualified as X
+
+{- | 'B.AlignDefault' yields 'Nothing' so the attribute is omitted entirely
+ rather than emitting an inline style that re-asserts the user-agent default.
+-}
+alignmentStyle :: B.Alignment -> Maybe (Text, Text)
+alignmentStyle = \case
+  B.AlignLeft -> Just ("style", "text-align: left")
+  B.AlignRight -> Just ("style", "text-align: right")
+  B.AlignCenter -> Just ("style", "text-align: center")
+  B.AlignDefault -> Nothing
+
+{- | Returns the empty list when every width is 'B.ColWidthDefault' — a
+ @\<colgroup\>@ full of bare @\<col\>@s would just be HTML noise.
+-}
+colSpecsToColgroup :: [B.ColSpec] -> [X.Node]
+colSpecsToColgroup specs
+  | all ((== B.ColWidthDefault) . snd) specs = mempty
+  | otherwise = one $ X.Element "colgroup" mempty (renderCol <$> specs)
+  where
+    renderCol (_, B.ColWidthDefault) = X.Element "col" mempty mempty
+    renderCol (_, B.ColWidth w) =
+      X.Element "col" [("style", "width: " <> percent w)] mempty
+    percent w = T.pack (showFFloat (Just 2) (w * 100) "") <> "%"
+
+-- | Spans of 1 are the HTML default and are omitted to avoid noise.
+cellSpanAttrs :: B.RowSpan -> B.ColSpan -> [(Text, Text)]
+cellSpanAttrs (B.RowSpan rs) (B.ColSpan cs) =
+  catMaybes
+    [ guard (rs > 1) $> ("rowspan", show rs)
+    , guard (cs > 1) $> ("colspan", show cs)
+    ]
+
+{- | A cell with @ColSpan n@ occupies indices @[i .. i+n-1]@, so the next
+ cell starts at @i+n@; zipping by list position would silently misalign
+ every cell after a merged one.
+-}
+cellColumnIndices :: [B.Cell] -> [Int]
+cellColumnIndices = go 0
+  where
+    go _ [] = []
+    go col (B.Cell _ _ _ (B.ColSpan cs) _ : rest) = col : go (col + cs) rest
+
+{- | Append @right@ onto @left@, but consolidate any duplicate @style@ keys
+ into one entry joined with @"; "@. xmlhtml passes attributes through
+ verbatim, so two @style@ entries reach the browser as two attributes on
+ one element — invalid HTML, with the later value silently dropped by
+ most engines.
+-}
+mergeStyleKVs :: [(Text, Text)] -> [(Text, Text)] -> [(Text, Text)]
+mergeStyleKVs left right =
+  let (styles, rest) = partition ((== "style") . fst) (left <> right)
+   in case styles of
+        [] -> rest
+        [single] -> rest <> [single]
+        multiple -> rest <> [("style", T.intercalate "; " (snd <$> multiple))]

--- a/test/Heist/Extra/Splices/Pandoc/RenderSpec.hs
+++ b/test/Heist/Extra/Splices/Pandoc/RenderSpec.hs
@@ -16,6 +16,7 @@ import Heist.Extra.Splices.Pandoc.Render (
   cellColumnIndices,
   cellSpanAttrs,
   colSpecsToColgroup,
+  mergeStyleKVs,
   rawNode,
   rpBlock,
  )
@@ -148,6 +149,30 @@ spec = do
 
     it "is empty for an empty row" $
       cellColumnIndices [] `shouldBe` []
+
+  describe "mergeStyleKVs (srid/emanote#27, regression)" $ do
+    it "passes a single style entry through unchanged" $
+      mergeStyleKVs [("style", "color: red")] []
+        `shouldBe` [("style", "color: red")]
+
+    it "preserves non-style entries verbatim and in order" $
+      mergeStyleKVs [("id", "x"), ("class", "c")] [("data-foo", "bar")]
+        `shouldBe` [("id", "x"), ("class", "c"), ("data-foo", "bar")]
+
+    it "joins two style entries with `; ` so the rendered HTML stays valid" $
+      mergeStyleKVs
+        [("style", "color: red")]
+        [("style", "text-align: left")]
+        `shouldBe` [("style", "color: red; text-align: left")]
+
+    it "joins three+ style entries from anywhere in the input" $
+      mergeStyleKVs
+        [("style", "a: 1"), ("class", "c"), ("style", "b: 2")]
+        [("style", "c: 3")]
+        `shouldBe` [("class", "c"), ("style", "a: 1; b: 2; c: 3")]
+
+    it "is the identity on empty inputs" $
+      mergeStyleKVs [] [] `shouldBe` []
 
   -- Integration: render real Pandoc Table values through `rpBlock` and
   -- assert the bytes that come out of xmlhtml. Covers every variant the
@@ -314,6 +339,22 @@ spec = do
         out <- renderBlockHtml hs tbl
         out `shouldSatisfy` ("id='cell-id'" `BS.isInfixOf`)
         out `shouldSatisfy` ("cell-class" `BS.isInfixOf`)
+
+      it "consolidates a cell-supplied `style` with the alignment style (no dup attr)" $ \hs -> do
+        -- Cell already carries a `style` (e.g. from raw HTML in the source);
+        -- column 0 is right-aligned, so the renderer adds another `style`.
+        -- The output must hold both values in a single attribute, not two.
+        let cell = B.Cell ("", [], [("style", "color: red")]) B.AlignDefault (B.RowSpan 1) (B.ColSpan 1) [PB.Plain [PB.Str "v"]]
+            tbl =
+              tableFromParts
+                [(B.AlignRight, B.ColWidthDefault)]
+                []
+                [[mkRow [cell]]]
+                []
+        out <- renderBlockHtml hs tbl
+        bsCount "style=" out `shouldBe` 1
+        out `shouldSatisfy` ("color: red" `BS.isInfixOf`)
+        out `shouldSatisfy` ("text-align: right" `BS.isInfixOf`)
 
 -- * Test helpers for the integration suite.
 

--- a/test/Heist/Extra/Splices/Pandoc/RenderSpec.hs
+++ b/test/Heist/Extra/Splices/Pandoc/RenderSpec.hs
@@ -5,15 +5,22 @@ import Blaze.ByteString.Builder (toByteString)
 import Control.Exception (evaluate)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
+import Data.Function ((&))
+import Data.Functor.Identity (Identity (..), runIdentity)
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
+import Heist qualified as H
+import Heist.Extra.Splices.Pandoc.Ctx (emptyRenderCtx)
 import Heist.Extra.Splices.Pandoc.Render (
   alignmentStyle,
+  cellColumnIndices,
   cellSpanAttrs,
   colSpecsToColgroup,
   rawNode,
+  rpBlock,
  )
 import Test.Hspec
+import Text.Pandoc.Builder qualified as PB
 import Text.Pandoc.Definition qualified as B
 import Text.XmlHtml qualified as X
 import Prelude
@@ -126,3 +133,262 @@ spec = do
     it "emits both attrs when both spans are greater than 1" $
       cellSpanAttrs (B.RowSpan 2) (B.ColSpan 4)
         `shouldBe` [("rowspan", "2"), ("colspan", "4")]
+
+  describe "cellColumnIndices (srid/emanote#27)" $ do
+    let plainCell cs = B.Cell B.nullAttr B.AlignDefault (B.RowSpan 1) (B.ColSpan cs) [PB.Plain [PB.Str "x"]]
+    it "is a simple [0..] enumeration when every cell spans one column" $
+      cellColumnIndices [plainCell 1, plainCell 1, plainCell 1] `shouldBe` [0, 1, 2]
+
+    it "advances by the span when a cell spans multiple columns" $
+      -- A 4-column row: cell0 (span 1) | cell1 (span 2 — covers cols 1+2) | cell2 (span 1 — col 3)
+      cellColumnIndices [plainCell 1, plainCell 2, plainCell 1] `shouldBe` [0, 1, 3]
+
+    it "handles a leading wide cell" $
+      cellColumnIndices [plainCell 3, plainCell 1] `shouldBe` [0, 3]
+
+    it "is empty for an empty row" $
+      cellColumnIndices [] `shouldBe` []
+
+  -- Integration: render real Pandoc Table values through `rpBlock` and
+  -- assert the bytes that come out of xmlhtml. Covers every variant the
+  -- new code path is supposed to honour.
+  beforeAll initEmptyHeistState $
+    describe "rpBlock B.Table (srid/emanote#27, integration)" $ do
+      it "renders a minimal one-cell table with header & body wrappers" $ \hs -> do
+        let tbl = simpleTable [(B.AlignDefault, B.ColWidthDefault)] [["H1"]] [[["v1"]]]
+        out <- renderBlockHtml hs tbl
+        out `shouldSatisfy` ("<table" `BS.isInfixOf`)
+        out `shouldSatisfy` ("<thead" `BS.isInfixOf`)
+        out `shouldSatisfy` ("<tbody" `BS.isInfixOf`)
+        out `shouldSatisfy` ("<th" `BS.isInfixOf`)
+        out `shouldSatisfy` ("<td" `BS.isInfixOf`)
+        -- No colgroup — every width is default.
+        out `shouldSatisfy` (not . ("<colgroup" `BS.isInfixOf`))
+        -- No tfoot — no foot rows.
+        out `shouldSatisfy` (not . ("<tfoot" `BS.isInfixOf`))
+
+      it "applies per-column alignment to every cell in that column" $ \hs -> do
+        -- One header row + one body row, each three cells across.
+        -- Each column's alignment must reach two cells.
+        let tbl =
+              simpleTable
+                [ (B.AlignLeft, B.ColWidthDefault)
+                , (B.AlignCenter, B.ColWidthDefault)
+                , (B.AlignRight, B.ColWidthDefault)
+                ]
+                [["L", "C", "R"]]
+                [[["a", "b", "c"]]]
+        out <- renderBlockHtml hs tbl
+        bsCount "text-align: left" out `shouldBe` 2
+        bsCount "text-align: center" out `shouldBe` 2
+        bsCount "text-align: right" out `shouldBe` 2
+
+      it "lets a cell-level Alignment override the column's default" $ \hs -> do
+        -- Column 0 is left-aligned; the body cell overrides to right.
+        let bodyCell = B.Cell B.nullAttr B.AlignRight (B.RowSpan 1) (B.ColSpan 1) [PB.Plain [PB.Str "x"]]
+            tbl =
+              tableFromParts
+                [(B.AlignLeft, B.ColWidthDefault)]
+                [mkRow [mkCell "H"]]
+                [[mkRow [bodyCell]]]
+                []
+        out <- renderBlockHtml hs tbl
+        out `shouldSatisfy` ("text-align: right" `BS.isInfixOf`)
+
+      it "emits a <colgroup> with widths when any column has a fixed width" $ \hs -> do
+        let tbl =
+              simpleTable
+                [(B.AlignDefault, B.ColWidth 0.3), (B.AlignDefault, B.ColWidth 0.7)]
+                [["H1", "H2"]]
+                [[["a"], ["b"]]]
+        out <- renderBlockHtml hs tbl
+        out `shouldSatisfy` ("<colgroup>" `BS.isInfixOf`)
+        out `shouldSatisfy` ("width: 30.00%" `BS.isInfixOf`)
+        out `shouldSatisfy` ("width: 70.00%" `BS.isInfixOf`)
+
+      it "emits rowspan / colspan only when greater than 1" $ \hs -> do
+        let wide = B.Cell B.nullAttr B.AlignDefault (B.RowSpan 1) (B.ColSpan 2) [PB.Plain [PB.Str "wide"]]
+            tall = B.Cell B.nullAttr B.AlignDefault (B.RowSpan 2) (B.ColSpan 1) [PB.Plain [PB.Str "tall"]]
+            normal = mkCell "n"
+            tbl =
+              tableFromParts
+                [(B.AlignDefault, B.ColWidthDefault), (B.AlignDefault, B.ColWidthDefault)]
+                [mkRow [mkCell "H1", mkCell "H2"]]
+                [[mkRow [wide], mkRow [tall, normal]]]
+                []
+        out <- renderBlockHtml hs tbl
+        out `shouldSatisfy` ("colspan='2'" `BS.isInfixOf`)
+        out `shouldSatisfy` ("rowspan='2'" `BS.isInfixOf`)
+        -- Single-span cells must not carry the attrs.
+        out `shouldSatisfy` (not . ("rowspan='1'" `BS.isInfixOf`))
+        out `shouldSatisfy` (not . ("colspan='1'" `BS.isInfixOf`))
+
+      it "respects ColSpan when resolving column alignment (regression)" $ \hs -> do
+        -- 4 columns: left, center, right, left.
+        -- Body row: [span-2 cell, plain cell, plain cell].
+        -- The span-2 cell sits at columns 0-1; the next cell must pick up
+        -- the *right* alignment (column 2), not the *center* (column 1)
+        -- that a naive zip-by-position would yield.
+        let bodyCells =
+              [ B.Cell B.nullAttr B.AlignDefault (B.RowSpan 1) (B.ColSpan 2) [PB.Plain [PB.Str "spanned"]]
+              , mkCell "third"
+              , mkCell "fourth"
+              ]
+            tbl =
+              tableFromParts
+                [ (B.AlignLeft, B.ColWidthDefault)
+                , (B.AlignCenter, B.ColWidthDefault)
+                , (B.AlignRight, B.ColWidthDefault)
+                , (B.AlignLeft, B.ColWidthDefault)
+                ]
+                [mkRow [mkCell "A", mkCell "B", mkCell "C", mkCell "D"]]
+                [[mkRow bodyCells]]
+                []
+        out <- renderBlockHtml hs tbl
+        -- The body must contain a right-aligned cell ("third"). Without
+        -- the colspan-aware index resolution, "third" would inherit
+        -- column 1's center alignment instead.
+        let bodyHtml = snd $ BS.breakSubstring "<tbody" out
+        bodyHtml `shouldSatisfy` ("text-align: right" `BS.isInfixOf`)
+        bodyHtml `shouldSatisfy` ("text-align: left" `BS.isInfixOf`)
+        bodyHtml `shouldSatisfy` ("third</td>" `BS.isInfixOf`)
+        bodyHtml `shouldSatisfy` ("fourth</td>" `BS.isInfixOf`)
+
+      it "renders a table footer when present" $ \hs -> do
+        let tbl =
+              tableFromParts
+                [(B.AlignDefault, B.ColWidthDefault)]
+                [mkRow [mkCell "H"]]
+                [[mkRow [mkCell "v"]]]
+                [mkRow [mkCell "F"]]
+        out <- renderBlockHtml hs tbl
+        out `shouldSatisfy` ("<tfoot" `BS.isInfixOf`)
+        out `shouldSatisfy` ("F</td>" `BS.isInfixOf`)
+
+      it "omits <thead> when the head has no rows" $ \hs -> do
+        let tbl =
+              tableFromParts
+                [(B.AlignDefault, B.ColWidthDefault)]
+                []
+                [[mkRow [mkCell "v"]]]
+                []
+        out <- renderBlockHtml hs tbl
+        out `shouldSatisfy` (not . ("<thead" `BS.isInfixOf`))
+        out `shouldSatisfy` ("<tbody" `BS.isInfixOf`)
+
+      it "preserves the table-level Attr on the <table> element" $ \hs -> do
+        let attr = ("my-table-id", ["custom-tw"], [("data-foo", "bar")])
+            tbl =
+              B.Table
+                attr
+                PB.emptyCaption
+                [(B.AlignDefault, B.ColWidthDefault)]
+                (B.TableHead B.nullAttr [])
+                [B.TableBody B.nullAttr 0 [] [B.Row B.nullAttr [mkCell "v"]]]
+                (B.TableFoot B.nullAttr [])
+        out <- renderBlockHtml hs tbl
+        out `shouldSatisfy` ("id='my-table-id'" `BS.isInfixOf`)
+        out `shouldSatisfy` ("custom-tw" `BS.isInfixOf`)
+        out `shouldSatisfy` ("data-foo='bar'" `BS.isInfixOf`)
+
+      it "preserves Row Attr on the <tr> element" $ \hs -> do
+        let row = B.Row ("row-id", ["row-class"], []) [mkCell "v"]
+            tbl =
+              tableFromParts
+                [(B.AlignDefault, B.ColWidthDefault)]
+                []
+                [[row]]
+                []
+        out <- renderBlockHtml hs tbl
+        out `shouldSatisfy` ("id='row-id'" `BS.isInfixOf`)
+        out `shouldSatisfy` ("row-class" `BS.isInfixOf`)
+
+      it "preserves Cell Attr on the <td> element" $ \hs -> do
+        let cell = B.Cell ("cell-id", ["cell-class"], []) B.AlignDefault (B.RowSpan 1) (B.ColSpan 1) [PB.Plain [PB.Str "v"]]
+            tbl =
+              tableFromParts
+                [(B.AlignDefault, B.ColWidthDefault)]
+                []
+                [[mkRow [cell]]]
+                []
+        out <- renderBlockHtml hs tbl
+        out `shouldSatisfy` ("id='cell-id'" `BS.isInfixOf`)
+        out `shouldSatisfy` ("cell-class" `BS.isInfixOf`)
+
+-- * Test helpers for the integration suite.
+
+{- | Build a fresh 'H.HeistState Identity' with no templates loaded.
+ 'rpBlock' on a table never reaches 'getParamNode' / template lookup,
+ so an empty state is sufficient. The namespace is cleared because
+ 'initHeist' otherwise complains when no @h:@-prefixed splices are
+ bound — an inert default that's just noise for these tests.
+-}
+initEmptyHeistState :: IO (H.HeistState Identity)
+initEmptyHeistState = do
+  let cfg :: H.HeistConfig Identity
+      cfg = H.emptyHeistConfig & H.hcNamespace (const $ Identity "") & runIdentity
+  res <- H.initHeist cfg
+  case res of
+    Left errs -> error $ "initHeist failed: " <> show errs
+    Right hs -> pure hs
+
+-- | Render a single Pandoc 'B.Block' to UTF-8 HTML bytes.
+renderBlockHtml :: H.HeistState Identity -> B.Block -> IO ByteString
+renderBlockHtml hs b =
+  let nodes = runIdentity $ H.evalHeistT (rpBlock emptyRenderCtx b) (X.TextNode "") hs
+   in renderHtml nodes
+
+-- | A 'Cell' with default alignment, span 1, and plain inline content.
+mkCell :: Text -> B.Cell
+mkCell t = B.Cell B.nullAttr B.AlignDefault (B.RowSpan 1) (B.ColSpan 1) [PB.Plain [PB.Str t]]
+
+-- | Wrap a list of cells in a default-attr row.
+mkRow :: [B.Cell] -> B.Row
+mkRow = B.Row B.nullAttr
+
+{- | A 'B.Table' built from plain text head / body / foot rows.
+ One row per @[Text]@; each text becomes one default cell.
+-}
+simpleTable :: [B.ColSpec] -> [[Text]] -> [[[Text]]] -> B.Block
+simpleTable specs headRows bodyRows =
+  tableFromParts
+    specs
+    (textRow <$> headRows)
+    [textRow <$> rs | rs <- bodyRows]
+    []
+  where
+    textRow = mkRow . fmap mkCell
+
+{- | Same as 'simpleTable' but takes pre-built 'B.Row' values so callers
+ can exercise rowspan, colspan, attrs, and per-cell alignment.
+-}
+tableFromParts ::
+  [B.ColSpec] ->
+  -- | Head rows.
+  [B.Row] ->
+  -- | Bodies (each a list of rows).
+  [[B.Row]] ->
+  -- | Foot rows.
+  [B.Row] ->
+  B.Block
+tableFromParts specs headRows bodyRows footRows =
+  B.Table
+    B.nullAttr
+    PB.emptyCaption
+    specs
+    (B.TableHead B.nullAttr headRows)
+    [B.TableBody B.nullAttr 0 [] rs | rs <- bodyRows]
+    (B.TableFoot B.nullAttr footRows)
+
+-- | Substring occurrence count.
+bsCount :: ByteString -> ByteString -> Int
+bsCount needle = go 0
+  where
+    nl = BS.length needle
+    go n hay
+      | BS.null hay = n
+      | otherwise =
+          let (_, rest) = BS.breakSubstring needle hay
+           in if BS.null rest
+                then n
+                else go (n + 1) (BS.drop nl rest)

--- a/test/Heist/Extra/Splices/Pandoc/RenderSpec.hs
+++ b/test/Heist/Extra/Splices/Pandoc/RenderSpec.hs
@@ -155,7 +155,7 @@ spec = do
   beforeAll initEmptyHeistState $
     describe "rpBlock B.Table (srid/emanote#27, integration)" $ do
       it "renders a minimal one-cell table with header & body wrappers" $ \hs -> do
-        let tbl = simpleTable [(B.AlignDefault, B.ColWidthDefault)] [["H1"]] [[["v1"]]]
+        let tbl = simpleTable [(B.AlignDefault, B.ColWidthDefault)] [["H1"]] [["v1"]]
         out <- renderBlockHtml hs tbl
         out `shouldSatisfy` ("<table" `BS.isInfixOf`)
         out `shouldSatisfy` ("<thead" `BS.isInfixOf`)
@@ -177,7 +177,7 @@ spec = do
                 , (B.AlignRight, B.ColWidthDefault)
                 ]
                 [["L", "C", "R"]]
-                [[["a", "b", "c"]]]
+                [["a", "b", "c"]]
         out <- renderBlockHtml hs tbl
         bsCount "text-align: left" out `shouldBe` 2
         bsCount "text-align: center" out `shouldBe` 2
@@ -200,7 +200,7 @@ spec = do
               simpleTable
                 [(B.AlignDefault, B.ColWidth 0.3), (B.AlignDefault, B.ColWidth 0.7)]
                 [["H1", "H2"]]
-                [[["a"], ["b"]]]
+                [["a", "b"]]
         out <- renderBlockHtml hs tbl
         out `shouldSatisfy` ("<colgroup>" `BS.isInfixOf`)
         out `shouldSatisfy` ("width: 30.00%" `BS.isInfixOf`)
@@ -346,21 +346,18 @@ mkCell t = B.Cell B.nullAttr B.AlignDefault (B.RowSpan 1) (B.ColSpan 1) [PB.Plai
 mkRow :: [B.Cell] -> B.Row
 mkRow = B.Row B.nullAttr
 
-{- | A 'B.Table' built from plain text head / body / foot rows.
- One row per @[Text]@; each text becomes one default cell.
+{- | A 'B.Table' with plain-text rows. Each inner @[Text]@ is one row; each
+ text becomes one default cell. Single body — multi-body tables can use
+ 'tableFromParts'.
 -}
-simpleTable :: [B.ColSpec] -> [[Text]] -> [[[Text]]] -> B.Block
+simpleTable :: [B.ColSpec] -> [[Text]] -> [[Text]] -> B.Block
 simpleTable specs headRows bodyRows =
-  tableFromParts
-    specs
-    (textRow <$> headRows)
-    [textRow <$> rs | rs <- bodyRows]
-    []
+  tableFromParts specs (textRow <$> headRows) [textRow <$> bodyRows] []
   where
     textRow = mkRow . fmap mkCell
 
-{- | Same as 'simpleTable' but takes pre-built 'B.Row' values so callers
- can exercise rowspan, colspan, attrs, and per-cell alignment.
+{- | Like 'simpleTable' but with pre-built 'B.Row' values, so tests can
+ exercise rowspan, colspan, attrs, and per-cell alignment.
 -}
 tableFromParts ::
   [B.ColSpec] ->

--- a/test/Heist/Extra/Splices/Pandoc/RenderSpec.hs
+++ b/test/Heist/Extra/Splices/Pandoc/RenderSpec.hs
@@ -7,13 +7,20 @@ import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
-import Heist.Extra.Splices.Pandoc.Render (rawNode)
-import Prelude
+import Heist.Extra.Splices.Pandoc.Render (
+  alignmentStyle,
+  cellSpanAttrs,
+  colSpecsToColgroup,
+  rawNode,
+ )
 import Test.Hspec
+import Text.Pandoc.Definition qualified as B
 import Text.XmlHtml qualified as X
+import Prelude
 
--- | Force-render a node tree to bytes via xmlhtml's HTML5 fragment renderer.
--- Any `error` thrown by the renderer surfaces here.
+{- | Force-render a node tree to bytes via xmlhtml's HTML5 fragment renderer.
+ Any `error` thrown by the renderer surfaces here.
+-}
 renderHtml :: [X.Node] -> IO ByteString
 renderHtml = evaluate . toByteString . X.renderHtmlFragment X.UTF8
 
@@ -71,7 +78,51 @@ spec = do
       let body =
             "<svg xmlns=\"http://www.w3.org/2000/svg\">\
             \<foreignObject><div xmlns=\"http://www.w3.org/1999/xhtml\">\
-            \<span>label</span></div></foreignObject></svg>" :: Text
+            \<span>label</span></div></foreignObject></svg>" ::
+              Text
       out <- renderHtml (rawNode "div" body)
       out `shouldSatisfy` ("<foreignObject>" `BS.isInfixOf`)
       out `shouldSatisfy` ("</div>" `BS.isInfixOf`)
+
+  describe "alignmentStyle (srid/emanote#27)" $ do
+    it "maps the three explicit alignments to text-align styles" $ do
+      alignmentStyle B.AlignLeft `shouldBe` Just ("style", "text-align: left")
+      alignmentStyle B.AlignRight `shouldBe` Just ("style", "text-align: right")
+      alignmentStyle B.AlignCenter `shouldBe` Just ("style", "text-align: center")
+
+    it "drops AlignDefault entirely instead of emitting an empty style" $
+      alignmentStyle B.AlignDefault `shouldBe` Nothing
+
+  describe "colSpecsToColgroup (srid/emanote#27)" $ do
+    it "emits nothing when every column width is default" $ do
+      let specs = [(B.AlignLeft, B.ColWidthDefault), (B.AlignRight, B.ColWidthDefault)]
+      colSpecsToColgroup specs `shouldBe` mempty
+
+    it "emits a <colgroup> with width-bearing <col>s when any width is set" $ do
+      let specs = [(B.AlignDefault, B.ColWidth 0.25), (B.AlignDefault, B.ColWidth 0.75)]
+      out <- renderHtml (colSpecsToColgroup specs)
+      out `shouldSatisfy` ("<colgroup>" `BS.isInfixOf`)
+      out `shouldSatisfy` ("width: 25.00%" `BS.isInfixOf`)
+      out `shouldSatisfy` ("width: 75.00%" `BS.isInfixOf`)
+
+    it "emits a bare <col> for default-width columns mixed with sized ones" $ do
+      let specs = [(B.AlignDefault, B.ColWidth 0.5), (B.AlignDefault, B.ColWidthDefault)]
+      out <- renderHtml (colSpecsToColgroup specs)
+      out `shouldSatisfy` ("width: 50.00%" `BS.isInfixOf`)
+      -- xmlhtml self-closes the void <col> element. The default-width
+      -- column emits <col /> (no style attr).
+      out `shouldSatisfy` ("<col />" `BS.isInfixOf`)
+
+  describe "cellSpanAttrs (srid/emanote#27)" $ do
+    it "emits no attributes when both spans are 1 (HTML default)" $
+      cellSpanAttrs (B.RowSpan 1) (B.ColSpan 1) `shouldBe` []
+
+    it "emits rowspan only when the row span is greater than 1" $
+      cellSpanAttrs (B.RowSpan 3) (B.ColSpan 1) `shouldBe` [("rowspan", "3")]
+
+    it "emits colspan only when the column span is greater than 1" $
+      cellSpanAttrs (B.RowSpan 1) (B.ColSpan 2) `shouldBe` [("colspan", "2")]
+
+    it "emits both attrs when both spans are greater than 1" $
+      cellSpanAttrs (B.RowSpan 2) (B.ColSpan 4)
+        `shouldBe` [("rowspan", "2"), ("colspan", "4")]

--- a/test/Heist/Extra/Splices/Pandoc/RenderSpec.hs
+++ b/test/Heist/Extra/Splices/Pandoc/RenderSpec.hs
@@ -12,13 +12,15 @@ import Data.Text.Encoding (encodeUtf8)
 import Heist qualified as H
 import Heist.Extra.Splices.Pandoc.Ctx (emptyRenderCtx)
 import Heist.Extra.Splices.Pandoc.Render (
+  rawNode,
+  rpBlock,
+ )
+import Heist.Extra.Splices.Pandoc.Render.Internal (
   alignmentStyle,
   cellColumnIndices,
   cellSpanAttrs,
   colSpecsToColgroup,
   mergeStyleKVs,
-  rawNode,
-  rpBlock,
  )
 import Test.Hspec
 import Text.Pandoc.Builder qualified as PB


### PR DESCRIPTION
The `B.Table` arm of `rpBlock'` was reading only the header rows and
each cell's body — every other field of the AST was being discarded,
which left the carefully-typed alignment, widths, and span information
that pandoc-types and commonmark-hs both produce stuck in the parsed
tree, never reaching HTML.

This change honours the rest of the table AST while keeping the
existing tailwind border/padding classes untouched (the *"move
tailwind to pandoc.tpl"* TODO is a separate cleanup).

What now reaches the rendered table:

- **Column alignment** from `ColSpec` flows onto every cell as an
  inline `style="text-align: …"`. Cell-level `Alignment` overrides the
  column default when set — matching pandoc-types' semantics.
- **Column widths** from `ColSpec` emit a `<colgroup>` populated with
  `<col style="width: X%">`. When every column is `ColWidthDefault`
  the colgroup is omitted entirely so we don't add noise.
- **`rowspan` / `colspan`** on `Cell` are emitted when greater than 1
  (HTML's default of 1 stays implicit).
- **Row `Attr` and Cell `Attr`** are merged into the rendered
  `<tr>` / `<th>` / `<td>` alongside the existing tailwind classes.
- **`TableFoot` rows** are now rendered into a `<tfoot>` — they were
  previously discarded.

Captions are still skipped: commonmark-hs doesn't emit them and the
existing TODO covers them separately.

Three pure helpers (`alignmentStyle`, `colSpecsToColgroup`,
`cellSpanAttrs`) are exported so the unit suite can pin behaviour
without touching the Heist splice machinery; the integration is
exercised end-to-end by emanote's e2e suite via the companion PR
that bumps the pin.

Refs srid/emanote#27.